### PR TITLE
Fix: Correct ReferenceError for r2UnitCountInput in script.js

### DIFF
--- a/src/static/script.js
+++ b/src/static/script.js
@@ -231,12 +231,12 @@ document.addEventListener('DOMContentLoaded', () => {
             playerR2PoolDisplay.textContent = R2_MAX_UNITS;
             r2MaxUnitsLabel.textContent = R2_MAX_UNITS;
             
-            // Ensure r2UnitCountInput is correctly defined and accessed
-            if (r2UnitCountInput) { // Check if the element was found
-                r2UnitCountInput.max = R2_MAX_UNITS; 
-                r2UnitCountInput.value = Math.min(10, R2_MAX_UNITS); // Default R2 count
+            // Ensure r2BatchUnitCountInput is correctly defined and accessed
+            if (r2BatchUnitCountInput) { // Check if the element was found
+                r2BatchUnitCountInput.max = R2_MAX_UNITS; 
+                r2BatchUnitCountInput.value = Math.min(10, R2_MAX_UNITS); // Default R2 count
             } else {
-                console.error("Error: r2-unit-count element not found in HTML!");
+                console.error("Error: r2-batch-unit-count element not found in HTML!");
                 showMessage("Critical UI Error: R2 count input missing.", true);
             }
 


### PR DESCRIPTION
Corrects a typo in `src/static/script.js` where `r2UnitCountInput` was used instead of the correctly defined `r2BatchUnitCountInput`.

This error occurred in the `r1FinalizeButton` event listener when attempting to set the `.max` and `.value` properties for the Round 2 unit count input field after Round 1 finalization.

The specific changes made are:
- Renamed `r2UnitCountInput.max` to `r2BatchUnitCountInput.max`.
- Renamed `r2UnitCountInput.value` to `r2BatchUnitCountInput.value`.
- Updated a related `console.error` message to refer to the correct ID `r2-batch-unit-count`.

This resolves the "ReferenceError: r2UnitCountInput is not defined" that was logged when finalizing Round 1.