### PR TITLE
Fix: Correct R2 submission payload and data handling

### DIFF
--- a/src/static/script.js
+++ b/src/static/script.js
@@ -60,6 +60,8 @@ document.addEventListener('DOMContentLoaded', () => {
     let aiR1ArmyDetailsForR2 = null;
     let aiR2DataForR2 = null;
     let playerR1DeploymentsForR2 = null; // Player's R1 deployments also need to be sent for map reconstruction
+    let aiR1DeploymentsForR2 = null; 
+    let playerR2TotalPoolForR2 = null;
 
     // --- Utility Functions ---
     function showMessage(message, isError = false) {
@@ -226,7 +228,9 @@ document.addEventListener('DOMContentLoaded', () => {
             R2_MAX_UNITS = data.player_r2_data.total_r2_pool;
             aiR1ArmyDetailsForR2 = data.ai_r1_army_details_for_r2; // Store for R2
             aiR2DataForR2 = data.ai_r2_data_for_r2;                 // Store for R2
-            playerR1DeploymentsForR2 = r1Deployments; // Store player's R1 deployments
+            playerR1DeploymentsForR2 = data.player_r1_deployments; // Store player's R1 deployments
+            aiR1DeploymentsForR2 = data.ai_r1_deployments;
+            playerR2TotalPoolForR2 = data.player_r2_data.total_r2_pool; 
 
             playerR2PoolDisplay.textContent = R2_MAX_UNITS;
             r2MaxUnitsLabel.textContent = R2_MAX_UNITS;
@@ -308,14 +312,16 @@ document.addEventListener('DOMContentLoaded', () => {
         r2AddBatchButton.disabled = true;
 
         try {
+            console.log("Submitting to /submit_round_2 payload:", JSON.stringify({ player_deployments_r2: r2Deployments, ai_r1_deployments: aiR1DeploymentsForR2, ai_r2_data_for_r2: aiR2DataForR2, player_r1_deployments: playerR1DeploymentsForR2, player_r2_total_pool: playerR2TotalPoolForR2 }, null, 2));
             const response = await fetch('/submit_round_2', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
                     player_deployments_r2: r2Deployments,
-                    ai_r1_army_details_for_r2: aiR1ArmyDetailsForR2,
+                    ai_r1_deployments: aiR1DeploymentsForR2,
                     ai_r2_data_for_r2: aiR2DataForR2,
-                    player_r1_deployments: playerR1DeploymentsForR2 // Send player's R1 deployments
+                    player_r1_deployments: playerR1DeploymentsForR2, 
+                    player_r2_total_pool: playerR2TotalPoolForR2 
                 }),
             });
             const data = await response.json();


### PR DESCRIPTION
Addresses an error in Round 2 ("Missing R1 deployment data or R2 pool data from client") by making the following changes to `src/static/script.js`:

1.  Stored `data.ai_r1_deployments` (as `aiR1DeploymentsForR2`) and `data.player_r2_data.total_r2_pool` (as `playerR2TotalPoolForR2`) from the R1 response. This ensures the complete AI R1 deployment data and your R2 unit pool are available for the R2 submission. Previously, only AI R1 army *details* were stored, and your R2 pool was not explicitly passed in the R2 payload.

2.  Updated the payload for the `/submit_round_2` request to:
    - Send `ai_r1_deployments: aiR1DeploymentsForR2` instead of `ai_r1_army_details_for_r2`.
    - Add `player_r2_total_pool: playerR2TotalPoolForR2`.

3.  The variable `playerR1DeploymentsForR2` is now correctly assigned `data.player_r1_deployments` from the R1 response, ensuring the `owner` field and other server-side structuring are maintained for the R1 player deployments sent in the R2 payload.

4.  Updated the diagnostic `console.log` for the R2 payload to reflect these changes.

These modifications ensure the client sends all necessary data in the expected format to the `/submit_round_2` endpoint, as defined in `launch.py`.