### PR TITLE
Fix: Use correct keys for R2 results in UI

### DIFF
--- a/src/static/script.js
+++ b/src/static/script.js
@@ -329,10 +329,10 @@ document.addEventListener('DOMContentLoaded', () => {
             if (!response.ok) { throw new Error(data.error || `HTTP error! Status: ${response.status}`); }
 
             const r2res = data.round_2_results;
-            playerR2ArmyDisplay.textContent = `Total ${r2res.player_army.count} units`;
-            playerR2StrengthDisplay.textContent = r2res.player_army.strength;
-            computerR2ArmyDisplay.textContent = `Total ${r2res.ai_army.count} units`;
-            computerR2StrengthDisplay.textContent = r2res.ai_army.strength;
+            playerR2ArmyDisplay.textContent = `Total ${r2res.player_army_summary_for_combat.count} units`;
+            playerR2StrengthDisplay.textContent = r2res.player_army_summary_for_combat.strength;
+            computerR2ArmyDisplay.textContent = `Total ${r2res.ai_army_summary_for_combat.count} units`;
+            computerR2StrengthDisplay.textContent = r2res.ai_army_summary_for_combat.strength;
             r2WinnerDisplay.textContent = r2res.round_winner;
             gameWinnerDisplay.textContent = data.game_winner;
             


### PR DESCRIPTION
Corrects a TypeError in `script.js` that occurred when trying to display Round 2 results. The client was attempting to access `data.round_2_results.player_army` and `data.round_2_results.ai_army`, but the server provides these under `player_army_summary_for_combat` and `ai_army_summary_for_combat` respectively.

Changed `script.js` to use the correct keys:
- `r2res.player_army_summary_for_combat.count`
- `r2res.player_army_summary_for_combat.strength`
- `r2res.ai_army_summary_for_combat.count`
- `r2res.ai_army_summary_for_combat.strength`

This ensures the client correctly parses the server's response for Round 2 and displays the results without error.