### PR TITLE
Feat: Implement graphical map display

### DIFF
--- a/src/static/script.js
+++ b/src/static/script.js
@@ -85,14 +85,43 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!mapState) return;
         for (let y = 0; y < 5; y++) {
             for (let x = 0; x < 5; x++) {
-                const cellId = `cell-${y}-${x}`; // Corrected ID format
+                const cellId = `cell-${y}-${x}`; // Corrected ID format based on existing code
                 const cell = document.getElementById(cellId);
                 if (cell) {
                     const cellData = mapState[y][x];
+                    cell.innerHTML = ''; // Clear the cell first
+
                     if (cellData) {
-                        cell.textContent = `${cellData.owner === 'P1' ? 'P' : 'AI'}:${cellData.unit_type.substring(0,3)}:${cellData.count}`;
+                        // Construct image filename
+                        let imageName = '';
+                        if (cellData.owner === 'P1') {
+                            imageName = `p1_${cellData.unit_type}.png`;
+                        } else if (cellData.owner === 'AI') {
+                            imageName = `ai_${cellData.unit_type}.png`;
+                        }
+
+                        if (imageName) {
+                            const imgElement = document.createElement('img');
+                            imgElement.src = `static/images/${imageName}`; // Path to image
+                            imgElement.alt = `${cellData.owner} ${cellData.unit_type}`;
+                            // Style for the image will be handled by CSS (next step)
+                            // but ensure it's display block for centering if CSS handles that
+                            imgElement.style.display = 'block'; 
+                            imgElement.style.margin = '0 auto'; // Basic centering for now
+
+                            const countElement = document.createElement('div');
+                            countElement.textContent = cellData.count;
+                            countElement.style.textAlign = 'center'; // Center the count text
+
+                            cell.appendChild(imgElement);
+                            cell.appendChild(countElement);
+                        } else {
+                            // Fallback if owner is not P1 or AI, or unit_type is unknown
+                            // Though current game logic ensures owner is P1 or AI
+                            cell.textContent = `${cellData.owner === 'P1' ? 'P' : 'AI'}:${cellData.unit_type.substring(0,3)}:${cellData.count}`;
+                        }
                     } else {
-                        cell.textContent = '-';
+                        cell.textContent = ''; // Make empty cells truly empty (or use a placeholder image if desired later)
                     }
                 }
             }

--- a/src/static/style.css
+++ b/src/static/style.css
@@ -42,3 +42,28 @@ span {
     font-size: 20px;
     font-weight: bold;
 }
+
+/* Styling for unit images in the map grid */
+#map-grid td img {
+    max-width: 70%; /* Allow a bit more space for count text */
+    max-height: 70%;
+    display: block; /* Already set inline, but good to have in CSS */
+    margin: 2px auto; /* Small margin, auto for horizontal centering */
+    object-fit: contain; /* Ensures aspect ratio is maintained if image is not square */
+}
+
+/* Styling for unit count text in the map grid */
+#map-grid td div {
+    font-size: 0.8em; /* Smaller font size for the count */
+    color: #333;     /* Dark grey color for count text */
+    text-align: center; /* Already set inline, but good to have in CSS */
+    line-height: 1;   /* Adjust line height to be compact */
+    font-weight: bold; /* Make count bold */
+}
+
+/* Ensure table cells can vertically align content if needed, though block/margin auto on img might handle it */
+#map-grid td {
+    vertical-align: middle; /* Vertically align cell content (image and text) */
+    height: 60px; /* Give cells a fixed height to ensure consistency, adjust as needed */
+    width: 60px; /* Give cells a fixed width */
+}


### PR DESCRIPTION
Updates the game to display unit images on the map instead of text.

Changes include:
- Modified `renderMap` function in `src/static/script.js` to:
    - Dynamically create `<img>` elements for units based on owner and type.
    - Construct image paths assuming images are in `src/static/images/`.
    - Create a `<div>` to display unit counts alongside images.
    - Clear cells before rendering and ensure empty cells are blank.
- Added CSS rules to `src/static/style.css` to:
    - Control the size and basic alignment of unit images in map cells.
    - Style the unit count text.
    - Set a default size for map cells and improve content alignment.

Note: This commit includes the code changes for displaying graphics. The actual image assets (`p1_infantry.png`, `ai_cavalry.png`, etc.) need to be added to the `src/static/images/` directory by you as per subsequent instructions.